### PR TITLE
Added missing managers search Query

### DIFF
--- a/src/routes/home/example-pages/missing-managers/+page.server.ts
+++ b/src/routes/home/example-pages/missing-managers/+page.server.ts
@@ -1,0 +1,43 @@
+import { getLimit, getPage, getSorters } from '$lib/Utils.js';
+import { createConfiguration } from '$lib/sailpoint/sdk.js';
+import { SearchApi, type IdentityDocument, type Search, type SearchApiSearchPostRequest } from 'sailpoint-api-client';
+
+export const load = async ({ url, locals }) => {
+	const config = createConfiguration(locals.session!.baseUrl, locals.idnSession!.access_token);
+	const api = new SearchApi(config);
+	
+	const page = getPage(url);
+	const limit = getLimit(url);
+	const sorters = getSorters(url);
+
+	const search: Search = {
+		indices: ['identities'],
+		query: {
+			query: `NOT _exists_:manager.id AND attributes.cloudLifecycleState:active`
+		},
+		sort: ['name']
+	};
+
+	const requestParams: SearchApiSearchPostRequest = {
+		search,
+		offset: Number(page) * Number(limit),
+		limit: Number(limit),
+		count: true
+	};
+
+	const reportResp = api.searchPost(requestParams);
+
+	const reportData = new Promise<IdentityDocument[]>((resolve) => {
+		reportResp.then((response) => {
+			resolve(response.data);
+		});
+	});
+
+	const totalCount = new Promise<number>((resolve) => {
+		reportResp.then((response) => {
+			resolve(response.headers['x-total-count']);
+		});
+	});
+
+	return { reportData, totalCount, params: {page, limit, sorters}};
+};

--- a/src/routes/home/example-pages/missing-managers/+page.svelte
+++ b/src/routes/home/example-pages/missing-managers/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+    import Paginator from '$lib/Components/Paginator.svelte';
+    import Progress from '$lib/Components/Progress.svelte';
+    import {
+        TriggerCodeModal,
+        formatDate,
+        createOnPageChange,
+        createOnAmountChange,
+        createOnGo
+    } from '$lib/Utils.js';
+    import { getModalStore } from '@skeletonlabs/skeleton';
+
+    export let data;
+
+    const modalStore = getModalStore();
+
+    $: onPageChange = createOnPageChange(
+        { ...data.params, filters: '', sorters},
+        '/home/example-pages/missing-managers'
+    );
+    $: onAmountChange = createOnAmountChange(
+        { ...data.params, filters: '', sorters},
+        '/home/example-pages/missing-managers'
+    );
+    $: onGo = createOnGo(
+        { ...data.params, filters: '', sorters },
+        '/home/example-pages/missing-managers'
+    );
+
+    let sorters = data.params.sorters || '';
+</script>
+
+<div class="flex justify-center flex-col align-middle">
+	<div class="card p-4">
+		<p class="text-2xl text-center">
+			List of identities without managers
+		</p>
+	</div>
+	{#await data.reportData}
+		<div class="grid h-full place-content-center p-8">
+			<Progress width="w-[100px]" />
+		</div>
+	{:then reportData}
+	{#await data.totalCount then totalCount}
+			{#if totalCount > 250 || Number(data.params.limit) < totalCount}
+				<div class="card p-4">
+					<Paginator
+						{onAmountChange}
+						{onGo}
+						{onPageChange}
+						settings={{
+							page: Number(data.params.page),
+							limit: Number(data.params.limit),
+							size: totalCount,
+							amounts: [5, 10, 50, 100, 250]
+						}}
+						bind:sorters
+						{totalCount}
+					/>
+				</div>
+			{/if}
+		{/await}
+		{#if reportData.length === 0}
+			<div class="card p-4">
+				<p class=" text-center text-success-500">No identities with missing managers found</p>
+			</div>
+		{:else}
+		<div class="table-container">
+			<table class="table">
+				<thead class="table-head">
+					<th> DisplayName </th>
+					<th> Identity ID </th>
+					<th> Sources </th>
+					<th> Created </th>
+					<th> Modified </th>
+					<th> Access Count </th>
+					<th> Entitlement Count </th>
+					<th> Role Count </th>
+					<th></th>
+				</thead>
+				<tbody class="table-body">
+					{#each reportData as identity}
+					<tr>
+						<td>
+							{identity.displayName}
+						</td>						
+						<td>
+							{identity.id}
+						</td>
+						<td>
+							{identity.accounts?.map((account) => account.source?.name).join(', ')}
+						</td>
+						<td>
+							{formatDate(identity.created)}
+						</td>
+						<td>
+							{formatDate(identity.modified)}
+						</td>
+						<td>
+							{identity.accessCount}
+						</td>
+						<td>
+							{identity.entitlementCount}
+						</td>
+						<td>
+							{identity.roleCount}
+						</td>
+						<td>
+								<div class="flex flex-col justify-center gap-1">									
+									<button
+										on:click={() => TriggerCodeModal(identity, modalStore)}
+										class="btn btn-sm variant-filled-primary text-sm !text-white"
+									>
+										View
+									</button>
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+		{/if}
+	{/await}
+</div>

--- a/src/routes/home/example-pages/reports.ts
+++ b/src/routes/home/example-pages/reports.ts
@@ -1,7 +1,7 @@
 export const reports = [
 	{
 		url: '/home/example-pages/missing-managers',
-		name: 'Active Identiites with Missing Managers',
+		name: 'Active Identities with Missing Managers',
 		description: 'This report will show all identities without manager'
 	},
 	{

--- a/src/routes/home/example-pages/reports.ts
+++ b/src/routes/home/example-pages/reports.ts
@@ -1,5 +1,10 @@
 export const reports = [
 	{
+		url: '/home/example-pages/missing-managers',
+		name: 'Active Identiites with Missing Managers',
+		description: 'This report will show all identities without manager'
+	},
+	{
 		url: '/home/example-pages/list-of-identities',
 		name: 'List of Identities',
 		description: 'This report will show all identities in the system'


### PR DESCRIPTION
Created a new search query for fetching "Active identities with missing managers"
I added a new folder to "/home/example-pages/missing-managers". There are 3 changes:

1. Created a new folder under example-pages and called it "missing-managers".
2. Added +page.svelte and +page.server.ts to that folder.
3. Edited the "/routes/home/example-pages/reports.ts" file to include the path/URL to the missing-managers