### PR TITLE
Updating build scripts and workflows

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
       - name: Build the App
-        run: npm run electron:build
+        run: npm run electron:build -- --publish=never
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
 
@@ -49,4 +49,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built-electron-app
-          path: release/sailpoint-ui-development-kit-1.0.0-arm64.dmg
+          path: release/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,32 +4,32 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - main
-
 
 permissions:
   contents: write
   packages: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
+  release:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          npm install
+        run: npm install
 
-      - name: Install Linux dependencies
+      - name: Install platform deps (Linux-only)
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
@@ -37,7 +37,8 @@ jobs:
       - name: Install Angular CLI Globally
         run: npm install -g @angular/cli
 
-      - name: Build Electron App
-        run: npm run build:all
+      - name: Build and Publish
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build:all -- --publish=always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'package.json'
 
 permissions:
   contents: write
@@ -11,12 +13,12 @@ permissions:
 
 jobs:
   version:
-    name: Determine version and create GitHub release
+    name: Tag and create GitHub release from package.json version
     runs-on: ubuntu-22.04
     outputs:
-      published: ${{ steps.semantic.outputs.new_release_published }}
-      version: ${{ steps.semantic.outputs.new_release_version }}
-      tag: ${{ steps.semantic.outputs.new_release_git_tag }}
+      published: ${{ steps.publish.outputs.published }}
+      version: ${{ steps.vars.outputs.version }}
+      tag: ${{ steps.vars.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,18 +28,57 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm install
+      - name: Read version from package.json
+        id: vars
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
 
-      - name: Semantic Release
-        id: semantic
-        uses: cycjimmy/semantic-release-action@v4
+      - name: Check if tag exists
+        id: check_tag
+        shell: bash
+        run: |
+          git fetch --tags
+          if git rev-parse -q --verify "refs/tags/${{ steps.vars.outputs.tag }}" >/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag
+        if: steps.check_tag.outputs.exists == 'false'
+        shell: bash
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.vars.outputs.tag }}" -m "Release ${{ steps.vars.outputs.tag }}"
+          git push origin "${{ steps.vars.outputs.tag }}"
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          name: ${{ steps.vars.outputs.tag }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ steps.vars.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          branch: main
+
+      - name: Set published output
+        id: publish
+        shell: bash
+        run: |
+          if [ "${{ steps.check_tag.outputs.exists }}" = "false" ]; then
+            echo "published=true" >> $GITHUB_OUTPUT
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+          fi
 
   build-and-publish:
     needs: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,46 @@ name: 'Release'
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: write
   packages: write
 
 jobs:
-  release:
+  version:
+    name: Determine version and create GitHub release
+    runs-on: ubuntu-22.04
+    outputs:
+      published: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      tag: ${{ steps.semantic.outputs.new_release_git_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: main
+
+  build-and-publish:
+    needs: version
+    if: needs.version.outputs.published == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -18,6 +49,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.version.outputs.tag }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -37,7 +71,7 @@ jobs:
       - name: Install Angular CLI Globally
         run: npm install -g @angular/cli
 
-      - name: Build and Publish
+      - name: Build and Publish artifacts to GitHub Release
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -59,10 +59,10 @@ jobs:
         run: npm run e2e
       
     - name: Build the app
-      run: npm run electron:build
+      run: npm run electron:build -- --publish=never
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: built-electron-app
-        path: release/sailpoint-ui-development-kit-1.0.0.AppImage
+        path: release/**

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,10 +54,10 @@ jobs:
        npm run e2e
 
     - name: Build the app
-      run: npm run electron:build
+      run: npm run electron:build -- --publish=never
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: built-electron-app
-        path: release\sailpoint-ui-development-kit 1.0.0.exe
+        path: release/**

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,22 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    ["@semantic-release/github", {
+      "assets": []
+    }]
+  ]
+}
+

--- a/package.json
+++ b/package.json
@@ -141,7 +141,14 @@
     "ts-node": "10.9.2",
     "typescript": "5.8.3",
     "wait-on": "8.0.3",
-    "webdriver-manager": "12.1.9"
+    "webdriver-manager": "12.1.9",
+    "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/commit-analyzer": "13.0.0",
+    "@semantic-release/git": "10.0.1",
+    "@semantic-release/github": "10.3.4",
+    "@semantic-release/npm": "12.0.1",
+    "@semantic-release/release-notes-generator": "14.0.1",
+    "semantic-release": "24.2.3"
   },
   "engines": {
     "node": ">= 16.14.0 || >= 18.10.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start": "concurrently \"npm run ng:serve\" \"npm run electron:dev\" --names \"angular,electron\" --prefix-colors \"#5C44E4,#FF3E00\"",
     "dev": "npm run start",
     "ng:serve": "ng serve -c web",
-    "build:all": "npm run -w build:sdk && npm run -w build:prod && npm run -w electron:build",
+    "build:all": "npm run build:sdk && npm run build:prod && npm run electron:build",
     "build": "npm run build:components && npm run electron:tsc && ng build --base-href ./",
     "build:components": "ng build sailpoint-components",
     "build:dev": "npm run build -- -c dev",


### PR DESCRIPTION
- Corrected the build command in package.json to remove the unnecessary `-w` flag.
- Modified GitHub workflows to include `--publish=never` for Electron builds in macOS, Ubuntu, and Windows configurations.
- Updated the release workflow to use Node.js version 24 and adjusted the build command to include `--publish=always` for publishing artifacts.
- Changed artifact paths to use a wildcard for better flexibility in artifact uploads.