### PR TITLE
Pin CI Node runtime to 24.15.0

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.15.0'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.15.0'
 
       - name: Ensure jq is available
         shell: bash
@@ -187,13 +187,13 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.15.0'
 
       - name: Set up Node.js (Unix)
         if: runner.os != 'Windows'
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '24.15.0'
           cache: 'npm'
 
       - name: Enable Windows long paths

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24'
+        node-version: '24.15.0'
         cache: 'npm'
 
     - name: Install Dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '24'
+        node-version: '24.15.0'
 
     - name: Enable Windows long paths
       shell: powershell


### PR DESCRIPTION
## Summary
- Pins CI workflows that use Node 24 to `24.15.0` so Electron install avoids the newer Node 24 regression.
- Keeps the existing npm-based workflow setup intact; this does not include the pnpm migration changes.

## Test plan
- Validated workflow YAML locally.
- Confirmed the broader pnpm PR rerun passed on Linux, Windows, and macOS with the same Node runtime pin.

Made with [Cursor](https://cursor.com)